### PR TITLE
Refactor LayerGroup to use a modifiable list of Layers.

### DIFF
--- a/lib/layer/layer.dart
+++ b/lib/layer/layer.dart
@@ -10,6 +10,7 @@ import '../geo/geo.dart';
 import '../geometry/geometry.dart' show Point2D;
 import './marker/marker.dart';
 import './vector/vector.dart' show Polygon, PathOptions, Polyline;
+import 'package:quiver/collection.dart';
 
 part 'feature_group.dart';
 part 'geo_json.dart';

--- a/lib/layer/layer_group.dart
+++ b/lib/layer/layer_group.dart
@@ -2,26 +2,40 @@ part of leaflet.layer;
 
 typedef LayerFunc(var layer);
 
+class _LayerList extends DelegatingList<Layer> {
+  final LayerGroup _group;
+  final List<Layer> _list = <Layer>[];
+
+  _LayerList(this._group);
+
+  List get delegate => _list;
+
+  @override
+  add(Layer value) {
+    super.add(value);
+    if (_group._map != null) {
+      _group._map.addLayer(value);
+    }
+  }
+}
+
 /**
  * LayerGroup is a class to combine several layers into one so that
  * you can manipulate the group (e.g. add/remove it) as one layer.
  */
 class LayerGroup extends Layer {
 
-  Map<int, Layer> _layers;
+//  Map<int, Layer> _layers;
+  _LayerList _layers;
+  List<Layer> get layers => _layers;
   LeafletMap _map;
 
   /**
    * Create a layer group, optionally given an initial set of layers.
    */
-  LayerGroup([List<Layer> layers=null]) {
-    _layers = {};
-
-    if (layers != null) {
-      for (int i = 0; i < layers.length; i++) {
-        addLayer(layers[i]);
-      }
-    }
+  LayerGroup([List<Layer> layers]) {
+    _layers = new _LayerList(this);
+    if (layers != null) _layers.addAll(layers);
   }
 
   /**
@@ -32,9 +46,6 @@ class LayerGroup extends Layer {
 
     _layers[id] = layer;
 
-    if (_map != null) {
-      _map.addLayer(layer);
-    }
   }
 
   /**
@@ -67,7 +78,8 @@ class LayerGroup extends Layer {
   bool hasLayer(Layer layer) {
     if (layer == null) { return false; }
 
-    return _layers.containsKey(getLayerId(layer));
+    return _layers.contains(layer);
+//    return _layers.containsKey(getLayerId(layer));
   }
 
   /**

--- a/test/layer/layer_group_test.dart
+++ b/test/layer/layer_group_test.dart
@@ -13,9 +13,9 @@ main() {
         final lg = new LayerGroup(),
             marker = new Marker(new LatLng(0, 0));
 
-        expect(lg.addLayer(marker), equals(lg));
+        lg.layers.add(marker);
 
-        expect(lg.hasLayer(marker), isTrue);
+        expect(lg.layers.contains(marker), isTrue);
       });
     });
     group('#removeLayer', () {
@@ -23,10 +23,10 @@ main() {
         final lg = new LayerGroup(),
             marker = new Marker(new LatLng(0, 0));
 
-        lg.addLayer(marker);
-        expect(lg.removeLayer(marker), equals(lg));
+        lg.layers.add(marker);
+        lg.layers.remove(marker);
 
-        expect(lg.hasLayer(marker), isFalse);
+        expect(lg.layers.contains(marker), isFalse);
       });
     });
     group('#clearLayers', () {
@@ -34,10 +34,10 @@ main() {
         final lg = new LayerGroup(),
             marker = new Marker(new LatLng(0, 0));
 
-        lg.addLayer(marker);
-        expect(lg.clearLayers(), equals(lg));
+        lg.layers.add(marker);
+        lg.layers.clear();
 
-        expect(lg.hasLayer(marker), isFalse);
+        expect(lg.layers.contains(marker), isFalse);
       });
     });
     group('#getLayers', () {
@@ -45,9 +45,9 @@ main() {
         final lg = new LayerGroup(),
             marker = new Marker(new LatLng(0, 0));
 
-        lg.addLayer(marker);
+        lg.layers.add(marker);
 
-        expect(lg.getLayers(), equals([marker]));
+        expect(lg.layers, equals([marker]));
       });
     });
     group('#eachLayer', () {
@@ -56,12 +56,12 @@ main() {
             marker = new Marker(new LatLng(0, 0)),
             ctx = { 'foo': 'bar' };
 
-        lg.addLayer(marker);
+        lg.layers.add(marker);
 
-        lg.eachLayer((layer) {
+        lg.layers.forEach((layer) {
           expect(layer, equals(marker));
           //expect(this).to.eql(ctx);
-        }, ctx);
+        });
       });
     });
   });

--- a/test/layer/layer_group_test.html
+++ b/test/layer/layer_group_test.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+
+<html>
+  <head>
+  	<meta charset="utf-8">
+    <title>layer_group_test</title>
+  </head>
+ 
+  <body>   
+    <script type="application/dart" src="layer_group_test.dart"></script>
+    <script src="packages/browser/dart.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
This is more idiomatic Dart as can be seen in Element.classes, Node.children, and NodeList. Updates to the lists are reflected in the underlying system.
